### PR TITLE
Marshmallow 3rc6

### DIFF
--- a/nway/nway_matching.py
+++ b/nway/nway_matching.py
@@ -380,6 +380,13 @@ class NwayMatching(ArgSchemaParser):
         self.pair_matches = []
         for fixed, moving in itertools.combinations(self.experiments, 2):
             pair_args = dict(self.args)
+            # marshmallow 3.0.0rc6 is less forgiving about extra keys around
+            # so, pop out the unused shared keys here
+            for popkey in [
+                    "pruning_method",
+                    "experiment_containers",
+                    "save_pairwise_results"]:
+                pair_args.pop(popkey)
             pair_args["fixed"] = fixed
             pair_args["moving"] = moving
             pair_args["output_json"] = os.path.join(

--- a/nway/schemas.py
+++ b/nway/schemas.py
@@ -84,7 +84,7 @@ class CommonMatchingSchema(ArgSchema):
         description="clipLimit for cv2 CLAHE")
 
     @mm.post_load
-    def hungarian_warn(self, data):
+    def hungarian_warn(self, data, **kwargs):
         if "Hungarian" in data['assignment_solver']:
             logger.warning("Hungarian method not recommended. It is not "
                            "stable under permutations for typical cell "

--- a/nway/schemas.py
+++ b/nway/schemas.py
@@ -89,6 +89,7 @@ class CommonMatchingSchema(ArgSchema):
             logger.warning("Hungarian method not recommended. It is not "
                            "stable under permutations for typical cell "
                            "matching. Use Blossom.")
+        return data
 
 
 class NwayMatchingSchema(CommonMatchingSchema):

--- a/nway/utils.py
+++ b/nway/utils.py
@@ -56,6 +56,9 @@ def create_nice_mask(experiment, output_directory):
         json.dump(full_dict, f, indent=2)
 
     experiment['nice_dict_path'] = dict_path
+    # marshmallow 3.0.0rc6 is less forgiving about extra keys around
+    # so, pop out the unused extra keys here
+    experiment.pop('stimulus_name')
 
     return experiment
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 marshmallow==3.0.0rc6
-argschema==2.0.0
+argschema==2.0.1
 numpy
 pillow
 scikit-image

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
-marshmallow<3.0
-argschema<2.0
+marshmallow==3.0.0rc6
+argschema
 numpy
 pillow
 scikit-image

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 marshmallow==3.0.0rc6
-argschema
+argschema==2.0.0
 numpy
 pillow
 scikit-image

--- a/test/test_diagnostics.py
+++ b/test/test_diagnostics.py
@@ -104,7 +104,9 @@ def test_NwayDiagnostics(new_output, tmpdir):
 
     args = {
             'input_json': new_output,
-            'output_pdf': fname}
+            'output_pdf': fname,
+            'log_level': "DEBUG"
+            }
 
     nd = nwdi.NwayDiagnostics(input_data=args, args=[])
     nd.run()
@@ -119,7 +121,9 @@ def test_NwayDiagnostics(new_output, tmpdir):
     args = {
             'input_json': ninput,
             'output_pdf': "tmp.pdf",
-            'use_input_dir': True}
+            'use_input_dir': True,
+            'log_level': "DEBUG"
+            }
     nd = nwdi.NwayDiagnostics(input_data=args, args=[])
     nd.run()
 

--- a/test/test_nway.py
+++ b/test/test_nway.py
@@ -36,6 +36,7 @@ def input_file(tmpdir):
             template.render(
                 output_dir=output_dir,
                 test_files_dir=str(thistest)))
+    rendered['log_level'] = "DEBUG"
     yield rendered
 
 

--- a/test/test_pairwise.py
+++ b/test/test_pairwise.py
@@ -110,7 +110,8 @@ def test_real_cost_data(input_file, tmpdir, solver):
             'assignment_solver': solver,
             'output_json': os.path.join(
                     output_dir,
-                    "{}_to_{}_output.json".format(moving['id'], fixed['id']))
+                    "{}_to_{}_output.json".format(moving['id'], fixed['id'])),
+            'log_level': "DEBUG"
             }
 
     pm = pairwise.PairwiseMatching(input_data=pair_args, args=[])


### PR DESCRIPTION
Upon a new release of argschema 2.0.0 (not the pre-release 2.0.0a1, which has breaking changes related to https://github.com/AllenInstitute/argschema/issues/94)
this branch should update this repo to a marshmallow 3.0.0rc6 compatibility, which is the pinned version in AllenSDK.
Probably this branch fails until that new release is available, as I pinned to an argschema release that does not exist.

NOTE: the actual new release version of argschema is now 2.0.1