### PR TITLE
Feature/translation estimation

### DIFF
--- a/nway/image_processing_utils.py
+++ b/nway/image_processing_utils.py
@@ -1,0 +1,145 @@
+import cv2
+import numpy as np
+import logging
+
+logger = logging.getLogger(__name__)
+logger.setLevel(logging.INFO)
+
+
+def register_image_pair(img_fixed: np.ndarray, img_moving: np.ndarray,
+                        maxCount: int, epsilon: float,
+                        motion_type: str, gaussFiltSize: int,
+                        preregister: bool = True) -> np.ndarray:
+    """find the transform that registers two images
+
+    Parameters
+    ----------
+    img_fixed : numpy.ndarray
+        CV_8U (uint8) or CV_32F (float32) fixed image
+    img_moving : numpy.ndarray
+        CV_8U (uint8) or CV_32F (float32) moving image
+    maxCount : int
+        passed as maxCount to opencv termination criteria
+    epsilon : float
+        passed as epsilon to opencv termination criteria
+    motion_type : str
+        one of the 4 possible motion types for opencv findTransformECC
+        see the dictionary cvmotion below for the 4 possible values
+    gaussFiltSize : int
+        passed to opencv findTransformECC(). An optional value
+        indicating size of gaussian blur filter
+    preregister: bool
+        whether to give a hint to cv2.findTransformECC from cv2.phaseCorrelate
+
+    Returns
+    -------
+    tform : :class:`numpy.ndarry`
+        3 x 3 transformation matrix
+
+    """
+
+    cvmotion = {
+            "MOTION_TRANSLATION": cv2.MOTION_TRANSLATION,
+            "MOTION_EUCLIDEAN": cv2.MOTION_EUCLIDEAN,
+            "MOTION_AFFINE": cv2.MOTION_AFFINE,
+            "MOTION_HOMOGRAPHY": cv2.MOTION_HOMOGRAPHY}
+
+    # Define termination criteria
+    criteria = (
+            cv2.TERM_CRITERIA_EPS | cv2.TERM_CRITERIA_COUNT,
+            maxCount,
+            epsilon)
+
+    dx = dy = 0.0
+    if preregister:
+        (dx, dy), _ = cv2.phaseCorrelate(img_fixed.astype('float32'),
+                                         img_moving.astype('float32'))
+
+    tform = np.array([[1.0, 0.0, dx],
+                      [0.0, 1.0, dy]]).astype('float32')
+    if motion_type == 'MOTION_HOMOGRAPHY':
+        hrow = np.array([0.0, 0.0, 1.0]).astype('float32')
+        tform = np.vstack((tform, hrow))
+
+    try:
+        # Run the ECC algorithm. The results are stored in warp_matrix.
+        ccval, tform = cv2.findTransformECC(
+                img_fixed,
+                img_moving,
+                tform,
+                cvmotion[motion_type],
+                criteria,
+                None,
+                gaussFiltSize)
+    except cv2.error:
+        logger.error("failed to align images.")
+        raise
+
+    # not all the transforms output 3 x 3
+    if tform.shape == (2, 3):
+        tform = np.vstack((tform, [0, 0, 1]))
+
+    return tform
+
+
+def contrast_adjust(image, CLAHE_grid, CLAHE_clip):
+    """contrast adjust images
+
+    Parameters
+    ----------
+    image: numpy.ndaray
+        image to pre-process. CV_8UC1 (uint8) or CV_16UC1 (uint16)
+    CLAHE_grid : int
+        passed as tileGridSize to cv2.createCLAHE. If -1, skipped
+    CLAHE_clip : float
+        passed as clipLimit to cv2.createCLAHE
+
+    Returns
+    -------
+    image: numpy.narray
+        contrast-adjusted image
+
+    """
+    if CLAHE_grid != -1:
+        clahe = cv2.createCLAHE(
+            clipLimit=CLAHE_clip,
+            tileGridSize=(CLAHE_grid, CLAHE_grid))
+        image = clahe.apply(image)
+    return image
+
+
+def warp_image(image, tform, motion_type, dst_shape):
+    """
+
+    Parameters
+    ----------
+    image: numpy.ndarray
+        image to warp. Assumes uint8
+    tform: numpy.ndarray
+        3x3 transformation matrix
+    motion_type: str
+        kind of motion. See function `register_image_pair` for possible
+        values
+    dst_shape: tuple
+        desired shape of warped image
+
+    Returns
+    -------
+    image: numpy.ndarray
+        warped image, forced to uint8
+
+    """
+    if motion_type == 'MOTION_HOMOGRAPHY':
+        warp = cv2.warpPerspective
+    else:
+        warp = cv2.warpAffine
+        if tform.shape[0] == 3:
+            tform = tform[0:2]
+
+    image = warp(
+            image,
+            tform,
+            dst_shape[::-1],
+            flags=cv2.INTER_LINEAR + cv2.WARP_INVERSE_MAP).astype(np.uint8)
+
+    return image

--- a/nway/pairwise_matching.py
+++ b/nway/pairwise_matching.py
@@ -13,6 +13,7 @@ from argschema import ArgSchemaParser
 
 from nway.schemas import PairwiseMatchingSchema, PairwiseOutputSchema
 import nway.utils as utils
+import nway.image_processing_utils as imutils
 
 logger = logging.getLogger(__name__)
 logger.setLevel(logging.INFO)
@@ -399,143 +400,10 @@ def transform_mask(moving, dst_shape, tform):
     return transformed_3d
 
 
-def register_image_pair(img_fixed, img_moving, maxCount,
-                        epsilon, motion_type, gaussFiltSize):
-    """find the transform that registers two images
-
-    Parameters
-    ----------
-    img_fixed : numpy.ndarray
-        CV_8U (uint8) or CV_32F (float32) fixed image
-    img_moving : numpy.ndarray
-        CV_8U (uint8) or CV_32F (float32) moving image
-    maxCount : int
-        passed as maxCount to opencv termination criteria
-    epsilon : float
-        passed as epsilon to opencv termination criteria
-    motion_type : str
-        one of the 4 possible motion types for opencv findTransformECC
-        see the dictionary cvmotion below for the 4 possible values
-    gaussFiltSize : int
-        passed to opencv findTransformECC(). An optional value
-        indicating size of gaussian blur filter
-
-    Returns
-    -------
-    tform : :class:`numpy.ndarry`
-        3 x 3 transformation matrix
-
-    """
-
-    cvmotion = {
-            "MOTION_TRANSLATION": cv2.MOTION_TRANSLATION,
-            "MOTION_EUCLIDEAN": cv2.MOTION_EUCLIDEAN,
-            "MOTION_AFFINE": cv2.MOTION_AFFINE,
-            "MOTION_HOMOGRAPHY": cv2.MOTION_HOMOGRAPHY}
-
-    # Define termination criteria
-    criteria = (
-            cv2.TERM_CRITERIA_EPS | cv2.TERM_CRITERIA_COUNT,
-            maxCount,
-            epsilon)
-
-    # roughly find the translation to help
-    (dx, dy), power = cv2.phaseCorrelate(img_fixed.astype('float32'),
-                                         img_moving.astype('float32'))
-
-    tform = np.array([[1.0, 0.0, dx],
-                      [0.0, 1.0, dy]]).astype('float32')
-    if motion_type == 'MOTION_HOMOGRAPHY':
-        hrow = np.array([0.0, 0.0, 1.0]).astype('float32')
-        tform = np.vstack((tform, hrow))
-
-    try:
-        # Run the ECC algorithm. The results are stored in warp_matrix.
-        ccval, tform = cv2.findTransformECC(
-                img_fixed,
-                img_moving,
-                tform,
-                cvmotion[motion_type],
-                criteria,
-                None,
-                gaussFiltSize)
-    except cv2.error:
-        logger.error("failed to align images.")
-        raise
-
-    # not all the transforms output 3 x 3
-    if tform.shape == (2, 3):
-        tform = np.vstack((tform, [0, 0, 1]))
-
-    return tform
-
-
-def contrast_adjust(image, CLAHE_grid, CLAHE_clip):
-    """contrast adjust images
-
-    Parameters
-    ----------
-    image: numpy.ndaray
-        image to pre-process. CV_8UC1 (uint8) or CV_16UC1 (uint16)
-    CLAHE_grid : int
-        passed as tileGridSize to cv2.createCLAHE. If -1, skipped
-    CLAHE_clip : float
-        passed as clipLimit to cv2.createCLAHE
-
-    Returns
-    -------
-    image: numpy.narray
-        contrast-adjusted image
-
-    """
-    if CLAHE_grid != -1:
-        clahe = cv2.createCLAHE(
-            clipLimit=CLAHE_clip,
-            tileGridSize=(CLAHE_grid, CLAHE_grid))
-        image = clahe.apply(image)
-    return image
-
-
-def warp_image(image, tform, motion_type, dst_shape):
-    """
-
-    Parameters
-    ----------
-    image: numpy.ndarray
-        image to warp. Assumes uint8
-    tform: numpy.ndarray
-        3x3 transformation matrix
-    motion_type: str
-        kind of motion. See function `register_image_pair` for possible
-        values
-    dst_shape: tuple
-        desired shape of warped image
-
-    Returns
-    -------
-    image: numpy.ndarray
-        warped image, forced to uint8
-
-    """
-    if motion_type == 'MOTION_HOMOGRAPHY':
-        warp = cv2.warpPerspective
-    else:
-        warp = cv2.warpAffine
-        if tform.shape[0] == 3:
-            tform = tform[0:2]
-
-    image = warp(
-            image,
-            tform,
-            dst_shape[::-1],
-            flags=cv2.INTER_LINEAR + cv2.WARP_INVERSE_MAP).astype(np.uint8)
-
-    return image
-
-
 def register_intensity_images(
         img_path_fixed, img_path_moving, maxCount,
-        epsilon, motion_type, gaussFiltSize, CLAHE_grid, CLAHE_clip):
+        epsilon, motion_type, gaussFiltSize, CLAHE_grid, CLAHE_clip,
+        preregister=True):
     """find the transform that registers two images
 
     Parameters
@@ -556,6 +424,8 @@ def register_intensity_images(
         passed as tileGridSize to cv2.createCLAHE
     CLAHE_clip : int
         passed as clipLimit to cv2.createCLAHE
+    preregister: bool
+        whether to give a hint to cv2.findTransformECC from cv2.phaseCorrelate
 
     Returns
     -------
@@ -574,15 +444,16 @@ def register_intensity_images(
         img_moving = np.array(im)
 
     # perform contrast adjustment
-    img_fixed = contrast_adjust(img_fixed, CLAHE_grid, CLAHE_clip)
-    img_moving = contrast_adjust(img_moving, CLAHE_grid, CLAHE_clip)
+    img_fixed = imutils.contrast_adjust(img_fixed, CLAHE_grid, CLAHE_clip)
+    img_moving = imutils.contrast_adjust(img_moving, CLAHE_grid, CLAHE_clip)
 
     # find the transform
-    tform = register_image_pair(img_fixed, img_moving, maxCount,
-                                epsilon, motion_type, gaussFiltSize)
+    tform = imutils.register_image_pair(img_fixed, img_moving, maxCount,
+                                        epsilon, motion_type, gaussFiltSize,
+                                        preregister)
 
     # warp the moving image
-    img_moving_warped = warp_image(
+    img_moving_warped = imutils.warp_image(
             img_moving,
             tform,
             motion_type,
@@ -619,7 +490,8 @@ class PairwiseMatching(ArgSchemaParser):
                 self.args['motionType'],
                 self.args['gaussFiltSize'],
                 self.args['CLAHE_grid'],
-                self.args['CLAHE_clip'])
+                self.args['CLAHE_clip'],
+                preregister=self.args['preregister'])
 
         if self.args['save_registered_image']:
             imfname = os.path.join(

--- a/nway/pairwise_matching.py
+++ b/nway/pairwise_matching.py
@@ -399,6 +399,134 @@ def transform_mask(moving, dst_shape, tform):
     return transformed_3d
 
 
+def register_image_pair(img_fixed, img_moving, maxCount,
+                        epsilon, motion_type, gaussFiltSize):
+    """find the transform that registers two images
+
+    Parameters
+    ----------
+    img_fixed : numpy.ndarray
+        CV_8U (uint8) or CV_32F (float32) fixed image
+    img_moving : numpy.ndarray
+        CV_8U (uint8) or CV_32F (float32) moving image
+    maxCount : int
+        passed as maxCount to opencv termination criteria
+    epsilon : float
+        passed as epsilon to opencv termination criteria
+    motion_type : str
+        one of the 4 possible motion types for opencv findTransformECC
+        see the dictionary cvmotion below for the 4 possible values
+    gaussFiltSize : int
+        passed to opencv findTransformECC(). An optional value
+        indicating size of gaussian blur filter
+
+    Returns
+    -------
+    tform : :class:`numpy.ndarry`
+        3 x 3 transformation matrix
+
+    """
+
+    cvmotion = {
+            "MOTION_TRANSLATION": cv2.MOTION_TRANSLATION,
+            "MOTION_EUCLIDEAN": cv2.MOTION_EUCLIDEAN,
+            "MOTION_AFFINE": cv2.MOTION_AFFINE,
+            "MOTION_HOMOGRAPHY": cv2.MOTION_HOMOGRAPHY}
+
+    # Define termination criteria
+    criteria = (
+            cv2.TERM_CRITERIA_EPS | cv2.TERM_CRITERIA_COUNT,
+            maxCount,
+            epsilon)
+
+    warp_matrix = np.eye(2, 3, dtype=np.float32)
+    if motion_type == 'MOTION_HOMOGRAPHY':
+        warp_matrix = np.eye(3, 3, dtype=np.float32)
+
+    try:
+        # Run the ECC algorithm. The results are stored in warp_matrix.
+        ccval, tform = cv2.findTransformECC(
+                img_fixed,
+                img_moving,
+                warp_matrix,
+                cvmotion[motion_type],
+                criteria,
+                None,
+                gaussFiltSize)
+    except cv2.error:
+        logger.error("failed to align images.")
+        raise
+
+    # not all the transforms output 3 x 3
+    if tform.shape == (2, 3):
+        tform = np.vstack((tform, [0, 0, 1]))
+
+    return tform
+
+
+def contrast_adjust(image, CLAHE_grid, CLAHE_clip):
+    """contrast adjust images
+
+    Parameters
+    ----------
+    image: numpy.ndaray
+        image to pre-process. CV_8UC1 (uint8) or CV_16UC1 (uint16)
+    CLAHE_grid : int
+        passed as tileGridSize to cv2.createCLAHE. If -1, skipped
+    CLAHE_clip : float
+        passed as clipLimit to cv2.createCLAHE
+
+    Returns
+    -------
+    image: numpy.narray
+        contrast-adjusted image
+
+    """
+    if CLAHE_grid != -1:
+        clahe = cv2.createCLAHE(
+            clipLimit=CLAHE_clip,
+            tileGridSize=(CLAHE_grid, CLAHE_grid))
+        image = clahe.apply(image)
+    return image
+
+
+def warp_image(image, tform, motion_type, dst_shape):
+    """
+
+    Parameters
+    ----------
+    image: numpy.ndarray
+        image to warp. Assumes uint8
+    tform: numpy.ndarray
+        3x3 transformation matrix
+    motion_type: str
+        kind of motion. See function `register_image_pair` for possible
+        values
+    dst_shape: tuple
+        desired shape of warped image
+
+    Returns
+    -------
+    image: numpy.ndarray
+        warped image, forced to uint8
+
+    """
+    if motion_type == 'MOTION_HOMOGRAPHY':
+        warp = cv2.warpPerspective
+    else:
+        warp = cv2.warpAffine
+        if tform.shape[0] == 3:
+            tform = tform[0:2]
+
+    image = warp(
+            image,
+            tform,
+            dst_shape[::-1],
+            flags=cv2.INTER_LINEAR + cv2.WARP_INVERSE_MAP).astype(np.uint8)
+
+    return image
+
+
 def register_intensity_images(
         img_path_fixed, img_path_moving, maxCount,
         epsilon, motion_type, gaussFiltSize, CLAHE_grid, CLAHE_clip):
@@ -433,65 +561,26 @@ def register_intensity_images(
 
     """
 
-    cvmotion = {
-            "MOTION_TRANSLATION": cv2.MOTION_TRANSLATION,
-            "MOTION_EUCLIDEAN": cv2.MOTION_EUCLIDEAN,
-            "MOTION_AFFINE": cv2.MOTION_AFFINE,
-            "MOTION_HOMOGRAPHY": cv2.MOTION_HOMOGRAPHY}
-
     # read average intensity images
     with PIL.Image.open(img_path_fixed) as im:
         img_fixed = np.array(im)
     with PIL.Image.open(img_path_moving) as im:
         img_moving = np.array(im)
 
-    if CLAHE_grid != -1:
-        clahe = cv2.createCLAHE(
-            clipLimit=CLAHE_clip,
-            tileGridSize=(CLAHE_grid, CLAHE_grid))
-        img_fixed = clahe.apply(img_fixed)
-        img_moving = clahe.apply(img_moving)
+    # perform contrast adjustment
+    img_fixed = contrast_adjust(img_fixed, CLAHE_grid, CLAHE_clip)
+    img_moving = contrast_adjust(img_moving, CLAHE_grid, CLAHE_clip)
 
-    # Define termination criteria
-    criteria = (
-            cv2.TERM_CRITERIA_EPS | cv2.TERM_CRITERIA_COUNT,
-            maxCount,
-            epsilon)
+    # find the transform
+    tform = register_image_pair(img_fixed, img_moving, maxCount,
+                                epsilon, motion_type, gaussFiltSize)
 
-    warp_matrix = np.eye(2, 3, dtype=np.float32)
-    if motion_type == 'MOTION_HOMOGRAPHY':
-        warp_matrix = np.eye(3, 3, dtype=np.float32)
-
-    try:
-        # Run the ECC algorithm. The results are stored in warp_matrix.
-        ccval, tform = cv2.findTransformECC(
-                img_fixed,
-                img_moving,
-                warp_matrix,
-                cvmotion[motion_type],
-                criteria,
-                None,
-                gaussFiltSize)
-    except cv2.error:
-        logger.error("failed to align images {} and {}".format(
-            img_path_fixed,
-            img_path_moving))
-        raise
-
-    if motion_type == 'MOTION_HOMOGRAPHY':
-        warp = cv2.warpPerspective
-    else:
-        warp = cv2.warpAffine
-
-    img_moving_warped = warp(
+    # warp the moving image
+    img_moving_warped = warp_image(
             img_moving,
             tform,
-            img_fixed.shape[::-1],
-            flags=cv2.INTER_LINEAR + cv2.WARP_INVERSE_MAP).astype(np.uint8)
-
-    # if affine only, output full 3x3
-    if tform.shape == (2, 3):
-        tform = np.vstack((tform, [0, 0, 1]))
+            motion_type,
+            img_fixed.shape)
 
     return tform, img_moving_warped
 

--- a/nway/pairwise_matching.py
+++ b/nway/pairwise_matching.py
@@ -439,16 +439,22 @@ def register_image_pair(img_fixed, img_moving, maxCount,
             maxCount,
             epsilon)
 
-    warp_matrix = np.eye(2, 3, dtype=np.float32)
+    # roughly find the translation to help
+    (dx, dy), power = cv2.phaseCorrelate(img_fixed.astype('float32'),
+                                         img_moving.astype('float32'))
+
+    tform = np.array([[1.0, 0.0, dx],
+                      [0.0, 1.0, dy]]).astype('float32')
     if motion_type == 'MOTION_HOMOGRAPHY':
-        warp_matrix = np.eye(3, 3, dtype=np.float32)
+        hrow = np.array([0.0, 0.0, 1.0]).astype('float32')
+        tform = np.vstack((tform, hrow))
 
     try:
         # Run the ECC algorithm. The results are stored in warp_matrix.
         ccval, tform = cv2.findTransformECC(
                 img_fixed,
                 img_moving,
-                warp_matrix,
+                tform,
                 cvmotion[motion_type],
                 criteria,
                 None,

--- a/nway/schemas.py
+++ b/nway/schemas.py
@@ -79,6 +79,14 @@ class CommonMatchingSchema(ArgSchema):
         default=2.5,
         missing=2.5,
         description="clipLimit for cv2 CLAHE")
+    preregister = Bool(
+        required=False,
+        default=True,
+        missing=True,
+        description=("if True, cv2.phaseCorrelate will be used to estimate "
+                     "translation offsets before cv2.findTransformECC. This "
+                     "helps when there are significant offsets between two "
+                     "images."))
 
     @mm.post_load
     def hungarian_warn(self, data, **kwargs):

--- a/nway/schemas.py
+++ b/nway/schemas.py
@@ -71,8 +71,8 @@ class CommonMatchingSchema(ArgSchema):
         description="passed to opencv findTransformECC")
     CLAHE_grid = Int(
         required=False,
-        default=8,
-        missing=8,
+        default=24,
+        missing=24,
         description="tileGridSize for cv2 CLAHE, set to -1 to disable CLAHE")
     CLAHE_clip = Float(
         required=False,

--- a/test/test_image_processing_utils.py
+++ b/test/test_image_processing_utils.py
@@ -1,0 +1,193 @@
+import nway.image_processing_utils as imu
+import pytest
+from pathlib import Path
+import numpy as np
+import PIL.Image
+import cv2
+
+TEST_FILE_DIR = Path.resolve(Path(__file__)).parent / "test_files"
+
+
+@pytest.fixture
+def fixed_image():
+    # grab one specific file because failing large translation
+    # cases vary image-by-image
+    fgen = TEST_FILE_DIR.rglob("avgInt_a1X.png")
+    for f in fgen:
+        if "ophys_session_775289198" in str(f):
+            impath = f
+    with PIL.Image.open(impath) as fp:
+        image = np.array(fp)
+    return image
+
+
+@pytest.fixture
+def noisy_image(fixed_image):
+    flatim = np.flipud(np.fliplr(fixed_image))
+    return flatim
+
+
+@pytest.fixture
+def moving_image_fixture(fixed_image, request):
+    immoving = cv2.warpPerspective(
+            fixed_image,
+            request.param.get("transform"),
+            fixed_image.shape[::-1])
+    return immoving, request.param
+
+
+@pytest.mark.parametrize("preregister", [True, False])
+@pytest.mark.parametrize("motion_type, tform_tol, trans_tol", [
+    ("MOTION_TRANSLATION", (0.0001, 0.0001), (0.5, 0.0)),
+    ("MOTION_EUCLIDEAN", (0.0002, 0.0001), (0.5, 0.0)),
+    ("MOTION_AFFINE", (0.0005, 0.005), (0.5, 0.0)),
+    ("MOTION_HOMOGRAPHY", (0.005, 0.0001), (0.5, 0.0)),
+    ])
+@pytest.mark.parametrize(
+        "moving_image_fixture",
+        [
+           # identity
+           {"transform": np.array([[1.0, 0.0, 0.0],
+                                   [0.0, 1.0, 0.0],
+                                   [0.0, 0.0, 1.0]])},
+           # x translation
+           {"transform": np.array([[1.0, 0.0, 10.0],
+                                   [0.0, 1.0, 0.0],
+                                   [0.0, 0.0, 1.0]])},
+           # x and y translation
+           {"transform": np.array([[1.0, 0.0, 10.0],
+                                   [0.0, 1.0, -23.0],
+                                   [0.0, 0.0, 1.0]])},
+           # 5 deg rotation and x and y translation
+           {"transform": np.array([[np.cos(0.087), -np.sin(0.087), 10.0],
+                                   [np.sin(0.087), np.cos(0.087), -23.0],
+                                   [0.0, 0.0, 1.0]])},
+           ],
+        indirect=["moving_image_fixture"])
+def test_register_image_pair(fixed_image, moving_image_fixture, preregister,
+                             motion_type, tform_tol, trans_tol):
+    """
+    warp an image and see if the register image can recover the transform.
+    NOTE: in production, we are using MOTION_EUCLIDEAN as that is the
+    expected type of misalignment from the microscope rigs. The underlying
+    opencv functions support affine (includes scale) and homography/perspective
+    so those options are exposed in case of a new rig and some experimentation.
+
+    tform_tol is (abs, rel) tolerance on 2x2 multiplicative part
+    trans_tol is (abs, rel) tolerance of translations
+    (abs, rel) are as specified in np.testing.assert_allclose
+    As the order of desired transform goes up, it has more trouble
+    matching tolerance
+    """
+    moving_image, param = moving_image_fixture
+    expected_transform = param["transform"]
+    transform = imu.register_image_pair(
+            fixed_image,
+            moving_image,
+            500,
+            1e-3,
+            motion_type,
+            5,
+            preregister)
+
+    if not np.allclose(expected_transform[0:2, 0:2], np.eye(2)) & \
+            (motion_type == 'MOTION_TRANSLATION'):
+        # translation can't be expected to solve for rotation
+        pass
+    else:
+        # the multiplicative part of the transform
+        np.testing.assert_allclose(transform[0:2, 0:2],
+                                   expected_transform[0:2, 0:2],
+                                   atol=tform_tol[0], rtol=tform_tol[1])
+        # the translation part of the transform
+        np.testing.assert_allclose(transform[0:2, 2],
+                                   expected_transform[0:2, 2],
+                                   atol=trans_tol[0], rtol=trans_tol[1])
+
+
+@pytest.mark.parametrize("preregister", [True, False])
+@pytest.mark.parametrize("motion_type, tform_tol, trans_tol", [
+    ("MOTION_EUCLIDEAN", (0.1, 0.1), (0.5, 0.0)),
+    ])
+@pytest.mark.parametrize(
+        "moving_image_fixture, expect_success",
+        [
+            # x and y translation
+            ({"transform": np.array([[1.0, 0.0, 110.0],
+                                    [0.0, 1.0, -123.0],
+                                    [0.0, 0.0, 1.0]])}, True),
+            # small rotation
+            ({"transform": np.array([[np.cos(0.025), -np.sin(0.025), 110.0],
+                                    [np.sin(0.025), np.cos(0.025), -123.0],
+                                    [0.0, 0.0, 1.0]])}, True),
+            # the routine can't handle large rotations and translations
+            ({"transform": np.array([[np.cos(0.09), -np.sin(0.09), 110.0],
+                                    [np.sin(0.09), np.cos(0.09), -123.0],
+                                    [0.0, 0.0, 1.0]])}, False),
+            ],
+        indirect=["moving_image_fixture"])
+def test_preregister_for_big_translations(fixed_image, moving_image_fixture,
+                                          preregister, motion_type, tform_tol,
+                                          trans_tol, expect_success):
+    """ the preregistration fixes cases that fail for large offsets. These
+    are examples of those cases.
+    """
+    moving_image, param = moving_image_fixture
+    expected_transform = param["transform"]
+    transform = imu.register_image_pair(
+            fixed_image,
+            moving_image,
+            500,
+            1e-3,
+            motion_type,
+            5,
+            preregister)
+
+    if preregister & expect_success:
+        np.testing.assert_allclose(transform[0:2, 0:2],
+                                   expected_transform[0:2, 0:2],
+                                   atol=tform_tol[0], rtol=tform_tol[1])
+        np.testing.assert_allclose(transform[0:2, 2],
+                                   expected_transform[0:2, 2],
+                                   atol=trans_tol[0], rtol=trans_tol[1])
+    else:
+        # failure mode is typically a very small translation solution
+        assert not np.allclose(transform[0:2, 2],
+                               expected_transform[0:2, 2],
+                               atol=trans_tol[0], rtol=trans_tol[1])
+
+
+def test_failure_to_align(fixed_image, noisy_image):
+    with pytest.raises(
+            cv2.error,
+            match=(".*Images may be uncorrelated or non-overlapped "
+                   "in function 'findTransformECC")):
+        imu.register_image_pair(
+                fixed_image,
+                noisy_image,
+                50,
+                1e-7,
+                'MOTION_EUCLIDEAN',
+                5,
+                True)
+
+
+@pytest.mark.parametrize("CLAHE_GRID, CLAHE_CLIP",
+                         [(8, 2.5), (24, 2.5), (-1, 2.5)])
+def test_contrast_adjust(fixed_image, CLAHE_GRID, CLAHE_CLIP):
+    ca_image = imu.contrast_adjust(fixed_image, CLAHE_GRID, CLAHE_CLIP)
+    assert ca_image.shape == fixed_image.shape
+    assert ca_image.dtype == fixed_image.dtype
+
+
+@pytest.mark.parametrize("motion_type", [
+                         "MOTION_TRANSLATION", "MOTION_EUCLIDEAN",
+                         "MOTION_AFFINE", "MOTION_HOMOGRAPHY"])
+def test_warp_image(fixed_image, motion_type):
+    tform = np.array([[1.1, 0.1, 12.3],
+                      [-0.5, 0.94, -23],
+                      [0.0, 0.0, 1.0]])
+    warped = imu.warp_image(
+            fixed_image, tform, motion_type, fixed_image.shape)
+    assert warped.shape == fixed_image.shape
+    assert warped.dtype == 'uint8'

--- a/test/test_pairwise.py
+++ b/test/test_pairwise.py
@@ -265,7 +265,9 @@ def test_calculate_cost_matrix():
 
 @pytest.mark.parametrize('CLAHE_grid', [-1, 8])
 @pytest.mark.parametrize('motion', ['MOTION_AFFINE', 'MOTION_HOMOGRAPHY'])
-def test_register(input_file, tmpdir, motion, CLAHE_grid):
+def test_register_legacy(input_file, tmpdir, motion, CLAHE_grid):
+    """these tests pass with preregister=False
+    """
     CLAHE_clip = 2.5
     with open(input_file, 'r') as f:
         j = json.load(f)
@@ -302,7 +304,8 @@ def test_register(input_file, tmpdir, motion, CLAHE_grid):
             motion,
             5,
             CLAHE_grid,
-            CLAHE_clip)
+            CLAHE_clip,
+            preregister=False)
 
     # is the affine transform pretty close to what we put in?
     assert np.all(np.isclose(tform[0:2, 0:2], new_tform[0:2, 0:2], atol=0.005))
@@ -324,4 +327,5 @@ def test_register(input_file, tmpdir, motion, CLAHE_grid):
                     motion,
                     5,
                     CLAHE_grid,
-                    CLAHE_clip)
+                    CLAHE_clip,
+                    preregister=False)


### PR DESCRIPTION
Addresses [Investigate Multiscope cell matching output issue](https://app.zenhub.com/workspaces/allensdk-10-5c17f74db59cfb36f158db8c/issues/alleninstitute/allensdk/1506) and is the [implementation](https://app.zenhub.com/workspaces/allensdk-10-5c17f74db59cfb36f158db8c/issues/alleninstitute/ophys_nway_matching/33)

### Background
Cell matching was not working well on mesoscope containers. We determined the cause was a failure to register, because the mesoscope experiment-to-experiment alignment was worse than we've seen in the past.

### Fix
`cv2.findTransformECC` (the alignment algorithm) is known to struggle with "strong" misalignments:
```
Note that if images undergo strong displacements/rotations, an initial transformation that roughly aligns
the images is necessary (e.g., a simple euclidean/similarity transform that allows for the images showing
the same image content approximately).
```
[opencv docs](https://docs.opencv.org/4.4.0/dc/d6b/group__video__track.html#ga1aa357007eaec11e9ed03500ecbcbe47)

The solution implemented here is to first run [`cv2.phaseCorrelate`](https://docs.opencv.org/4.4.0/d7/df3/group__imgproc__motion.html#ga552420a2ace9ef3fb053cd630fdb4952) to find an estimate of the translation offsets, and then use those translations to seed the original algorithm (which can do higher order transforms than just translation, and which we use in production for Euclidean, i.e. rigid transforms).

In addition, in inspecting some of these alignment failures on real data, we found that some pairs were still failing to align. The `CLAHE` adjustments had been shown to help in the past, but in some cases, it seemed that a hazy CLAHE-originating artifact on the image border was biasing the registration. Adjusting the default CLAHE grid size from 8 to 24 reduced the size of this hazy artifact, and no further evidence of these types of failures persisted. @njmei suggested using the `inputMask` argument ot `findTransformECC` to mask out the border regions that seem to cause problems from CLAHE. This PR does not implement that suggestion in the interest of getting this fix into production to unblock other QC inspections for mesoscope data.

preregistering with `cv2.phaseCorrelate` and a `CLAHE` grid size of 24 are both the new default.