### PR TITLE
Docker and circleci

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,0 +1,64 @@
+jobs:
+  build38:
+    executor: 
+      name: python/default
+      tag: "3.8"
+    steps:
+      - checkout
+      - python/load-cache
+      - python/install-deps
+      - python/save-cache
+      - run:
+          command: |
+            python -m pytest --cov nway --cov-report xml
+            bash <(curl -s https://codecov.io/bash) -t ${CODECOV_TOKEN}
+          name: Test
+
+  lint:
+    executor: python/default
+    steps:
+      - checkout
+      - run:
+          command: |
+            pip install flake8
+            # `|| true` to force exit code 0 even if no files found
+            CHANGED_PYFILES=$(git diff --name-only --diff-filter AM origin/master | grep .py || true)
+            echo "List of changed files:"
+            echo ${CHANGED_PYFILES}
+            echo ${CHANGED_PYFILES} | xargs -r flake8 --count
+          name: Lint
+
+  docker:
+    machine: true
+    steps:
+      - checkout
+      - run: echo "$DOCKER_PASS" | docker login --username $DOCKER_USER --password-stdin
+      - run: 
+          name: Build and Push docker image
+          command: |
+            if [ "$CIRCLE_BRANCH" = "master" ]
+            then
+                MYTAG=master
+            else
+                MYTAG=develop
+            fi
+            # source/target tagging to alleviate concerns about unintended caching
+            image_source=alleninstitutepika/ophys_nway_matching:${CIRCLE_SHA1}
+            image_target=alleninstitutepika/ophys_nway_matching:${MYTAG}
+            docker build --build-arg MYBRANCH=${CIRCLE_BRANCH} -t ${image_source} .
+            docker run --entrypoint /bin/bash ${image_source} -c "python -m pytest"
+            docker tag ${image_source} ${image_target}
+            docker push ${image_target}
+
+orbs:
+  python: circleci/python@0.3.2
+version: 2.1
+workflows:
+  main:
+    jobs:
+      - build38
+      - lint
+      - docker:
+          requires:
+            - build38
+            - lint

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,17 @@
+FROM python:3.8.5
+
+ARG MYBRANCH=master
+
+RUN apt-get update && \
+    apt-get install -y \
+      git \
+      libgl1-mesa-glx \
+      libgtk2.0-dev
+
+RUN git clone https://github.com/AllenInstitute/ophys_nway_matching
+
+RUN cd ophys_nway_matching && \
+    git checkout ${MYBRANCH} && \
+    pip install .
+
+WORKDIR /ophys_nway_matching

--- a/README.md
+++ b/README.md
@@ -1,7 +1,22 @@
+[![CircleCI](https://circleci.com/gh/AllenInstitute/ophys_nway_matching.svg?style=svg)](https://circleci.com/gh/AllenInstitute/ophys_nway_matching)
 [![codecov](https://codecov.io/gh/AllenInstitute/ophys_nway_matching/branch/master/graph/badge.svg?token=y5Nt5RnMwB)](https://codecov.io/gh/AllenInstitute/ophys_nway_matching)
 
 # ophys_nway_matching
 N-way matching of segmented cell ROIs
+
+# Docker and Singularity
+A docker image is built in CircleCI and pushed to [dockerhub](https://hub.docker.com/repository/docker/alleninstitutepika/ophys_nway_matching) tagged as either `master` or `develop`.
+
+Singularity should be able to run this docker image directly:
+```
+singularity run docker://alleninstitutepika/ophys_nway_matching:develop python -m pytest /ophys_nway_matching
+```
+or
+```
+singularity run docker://alleninstitutepika/ophys_nway_matching:develop python -m nway.nway_matching --help
+```
+
+It appears the calling singularity in this way intelligently uses the local caches for both docker and singularity. There is an overhead for downloading an updated docker image and translating it to a singularity image. That cost is incurred only when the docker image has changed.
 
 # quick start
 


### PR DESCRIPTION
Adopt after #37 

### Overview
Establishes a container and CI/CD of that container.
* This can free us from the confusing bamboo builds of this repo and the deployment of its conda.
* Pins python version in code, not in bamboo config.
* Can work on this without VPN connection for bamboo.
* Container more reproducible than conda: In writing a test case for #35 I found that I could locally demonstrate an edge case that fails with legacy code and is fixed by the new `preregister` step. But, that edge case passes on the bamboo build agent. 
* utilizing this new container in production will require changing the LIMS executable to a singularity call.

### contents
* Defines a docker container
* Defines a CircleCI build workflow
* Docker image is auto-built and pushed to dockerhub
* Docker image does not include conda, and has been demonstrated to run through singularity (see README).

### docker note
In the past, I have encountered some issues running a docker image through singularity when the image has a conda env inside of it. Conda attempts to write a tempfile internally to /opt/conda/<etc> which is allowed by docker, but, throws an OS permission error when tried through singularity. This implementation does not have conda inside the image.