### PR TITLE
adds commit hash logging

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -45,7 +45,10 @@ jobs:
             # source/target tagging to alleviate concerns about unintended caching
             image_source=alleninstitutepika/ophys_nway_matching:${CIRCLE_SHA1}
             image_target=alleninstitutepika/ophys_nway_matching:${MYTAG}
-            docker build --build-arg MYBRANCH=${CIRCLE_BRANCH} -t ${image_source} .
+            docker build \
+                --build-arg MYBRANCH=${CIRCLE_BRANCH} \
+                --build-arg COMMIT=${CIRCLE_SHA1} \
+                -t ${image_source} .
             docker run --entrypoint /bin/bash ${image_source} -c "python -m pytest"
             docker tag ${image_source} ${image_target}
             docker push ${image_target}

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,7 @@
 FROM python:3.8.5
 
 ARG MYBRANCH=master
+ARG COMMIT=""
 
 RUN apt-get update && \
     apt-get install -y \
@@ -15,3 +16,5 @@ RUN cd ophys_nway_matching && \
     pip install .
 
 WORKDIR /ophys_nway_matching
+
+ENV NWAY_COMMIT_SHA=${COMMIT}

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 FROM python:3.8.5
 
 ARG MYBRANCH=master
-ARG COMMIT=""
+ARG COMMIT="unspecified to docker build"
 
 RUN apt-get update && \
     apt-get install -y \

--- a/nway/__init__.py
+++ b/nway/__init__.py
@@ -1,13 +1,3 @@
-# -*- coding: utf-8 -*-
-"""
-Created on Tue Mar 20 13:54:55 2018
-
-@author: fuhuil
-"""
-
-""" Top leavel package for ophys ophys cell matching"""
-
-__author__='Fuhui Long'
-__email__='fuhuil@alleninstitute.org'
-__version__='0.1'
-
+__author__ = "Fuhui Long, Daniel Kapner"
+__email__ = "danielk@alleninstitute.org"
+__version__ = "0.4"

--- a/nway/nway_matching.py
+++ b/nway/nway_matching.py
@@ -20,6 +20,7 @@ import networkx as nx
 from nway.pairwise_matching import PairwiseMatching
 from nway.schemas import NwayMatchingSchema, NwayMatchingOutputSchema
 import nway.utils as utils
+from nway import __version__ as nway_version
 from argschema import ArgSchemaParser
 
 logger = logging.getLogger(__name__)
@@ -376,6 +377,7 @@ class NwayMatching(ArgSchemaParser):
         # log this ENV variable, if present
         commit = os.environ.get("NWAY_COMMIT_SHA", None)
         logger.info(f"NWAY_COMMIT_SHA {commit}")
+        logger.info(f"Nway matching version {nway_version}")
 
         self.make_masks_from_dicts()
 

--- a/nway/nway_matching.py
+++ b/nway/nway_matching.py
@@ -373,6 +373,9 @@ class NwayMatching(ArgSchemaParser):
         """Nway cell matching by calling pairwise
            matching and then combining the results
         """
+        # log this ENV variable, if present
+        commit = os.environ.get("NWAY_COMMIT_SHA", None)
+        logger.info(f"NWAY_COMMIT_SHA {commit}")
 
         self.make_masks_from_dicts()
 


### PR DESCRIPTION
### This PR
* implements `python -m nway.nway_matching` to `logger.info` the ENV variable `NWAY_COMMIT_SHA` if it exists.
* sets the ENV variable `NWAY_COMMIT_SHA` inside the docker container to an ARG `COMMIT`
* sets the ARG `COMMIT` in the docker build step in the circleci build.

### Validation
```
$ docker run alleninstitutepika/ophys_nway_matching:develop bash -c 'echo $NWAY_COMMIT_SHA'
9bf94ff685221db485dda1b4863129fd9e4c149e

$ singularity run docker://alleninstitutepika/ophys_nway_matching:develop bash -c 'echo $NWAY_COMMIT_SHA'
WARNING: group: unknown groupid 10513
9bf94ff685221db485dda1b4863129fd9e4c149e
```