### PR TITLE
suppresses argschema list arg warning

### DIFF
--- a/nway/__init__.py
+++ b/nway/__init__.py
@@ -1,3 +1,3 @@
 __author__ = "Fuhui Long, Daniel Kapner"
 __email__ = "danielk@alleninstitute.org"
-__version__ = "0.4"
+__version__ = "0.4.1"

--- a/nway/schemas.py
+++ b/nway/schemas.py
@@ -20,6 +20,7 @@ class ExperimentSchema(DefaultSchema):
     cell_rois = List(
         Dict,
         required=True,
+        cli_as_single_argument=True,
         description='dict mapping of ids, labels, zs,')
     nice_mask_path = InputFile(
         required=True,


### PR DESCRIPTION
Example job output:
```
INFO:__main__:NWAY_COMMIT_SHA b5a028f4431f0fce1164365df8fda114b389b7d0
INFO:__main__:Nway matching version 0.4
/usr/local/lib/python3.8/site-packages/argschema/utils.py:346: FutureWarning: '--fixed.cell_rois' is using old-style command-line syntax with each element as a separate argument. This will not be supported in argschema after 2.0. See http://argschema.readthedocs.io/en/master/user/intro.html#command-line-specification for details.
warnings.warn(warn_msg, FutureWarning)
/usr/local/lib/python3.8/site-packages/argschema/utils.py:346: FutureWarning: '--moving.cell_rois' is using old-style command-line syntax with each element as a separate argument. This will not be supported in argschema after 2.0. See http://argschema.readthedocs.io/en/master/user/intro.html#command-line-specification for details.
warnings.warn(warn_msg, FutureWarning)
INFO:__main__:Nway matching is done!
INFO:__main__:wrote /allen/programs/braintv/production/visualbehavior/prod7/specimen_1032508324/experiment_container_1045477185/OphysNwayCellMatchingStrategy/container_run_1050765714/1045477185_ophys_cell_matching_output.json
```

This PR suppresses these warnings by updating to the new argschema CLI list spec.