### PR TITLE
adds more detail to logging

### DIFF
--- a/nway/nway_matching.py
+++ b/nway/nway_matching.py
@@ -402,6 +402,13 @@ class NwayMatching(ArgSchemaParser):
                 self.pair_matches = pool.map(pair_match_job, pair_arg_list)
 
         self.logger.name = type(self).__name__
+        df, id_map = utils.summarize_registration_success(
+                [p.args['output_json'] for p in self.pair_matches])
+        self.logger.info(f"registration success(1) or failure (0):\n{df}\n"
+                         f"id map{json.dumps(id_map, indent=2)}")
+        if not df.all(axis=None):
+            raise NwayException("not all pairwise registrations succeeded.")
+
         # generate N-way matching table
         matching_frame = self.gen_nway_table_with_redundancy()
 


### PR DESCRIPTION
2 changes:
* when a pariwise registration fails, this writes a file to disk and logs it. This will make it easier for processing support to look at particular failures:
```
INFO:PairwiseMatching:Matching 929655728 to 938002077: best registration was ['Identity']
INFO:PairwiseMatching:Matching 930996073 to 935514366
WARNING:PairwiseMatching:Matching 929655728 to 938002077: no registration found. wrote /home/danielk/tmp/avg_projections_929655728_938002077_20201123151906.png
```
and the image for that looks like:
![image](https://user-images.githubusercontent.com/32312979/100027561-e2069980-2da1-11eb-958c-f622d8380647.png)

* raising an exception for pairwise registration failures has been deferred to nway matching. This allows all registrations to be attempted and a summary matrix to be logged. Again, this is for making processing support for failures easier.
```
INFO:NwayMatching:registration success(1) or failure (0):
   0  1  2  3  4  5  6  7  8
0  1  0  1  0  0  0  0  0  0
1  0  1  1  1  1  1  1  1  1
2  1  1  1  1  1  1  1  1  1
3  0  1  1  1  1  1  1  1  1
4  0  1  1  1  1  1  1  1  1
5  0  1  1  1  1  1  1  1  1
6  0  1  1  1  1  1  1  1  1
7  0  1  1  1  1  1  1  1  1
8  0  1  1  1  1  1  1  1  1
id map{
  "0": 929655728,
  "1": 930996073,
  "2": 932372705,
  "3": 935514366,
  "4": 936500611,
  "5": 938002077,
  "6": 939471278,
  "7": 940433470,
  "8": 943518716
}
Traceback (most recent call last):
  File "/home/danielk/miniconda3/envs/nway38/lib/python3.8/runpy.py", line 194, in _run_module_as_main
    return _run_code(code, main_globals, None,
  File "/home/danielk/miniconda3/envs/nway38/lib/python3.8/runpy.py", line 87, in _run_code
    exec(code, run_globals)
  File "/home/danielk/repos/ophys_nway_matching/nway/nway_matching.py", line 433, in <module>
    nmod.run()
  File "/home/danielk/repos/ophys_nway_matching/nway/nway_matching.py", line 410, in run
    raise NwayException("not all pairwise registrations succeeded.")
__main__.NwayException: not all pairwise registrations succeeded.
```
in this case, from just the log, we can be pretty suspicious of experiment `929655728`.