### PR TITLE
adds meaningful exception for mismatched image sizes

### DIFF
--- a/nway/nway_matching.py
+++ b/nway/nway_matching.py
@@ -129,8 +129,8 @@ def check_image_sizes(image_paths: List[Path]):
             im = PIL.Image.open(fp)
             sizes.update({str(image_path): im.size})
     try:
-        for a, b in itertools.combinations(sizes.values(), 2):
-            assert a == b
+        sz0 = next(iter(sizes.values()))
+        assert all([i == sz0 for i in sizes.values()])
     except AssertionError:
         estr = "\n".join([f"{v}: {k}"
                           for k, v in sizes.items()])

--- a/nway/nway_matching.py
+++ b/nway/nway_matching.py
@@ -7,6 +7,8 @@ import multiprocessing
 import pandas as pd
 import networkx as nx
 import PIL.Image
+from pathlib import Path
+from typing import List
 from nway.pairwise_matching import PairwiseMatching
 from nway.schemas import NwayMatchingSchema, NwayMatchingOutputSchema
 import nway.utils as utils
@@ -120,6 +122,24 @@ def pair_match_job(pair_args):
     return pair_match
 
 
+def check_image_sizes(image_paths: List[Path]):
+    sizes = dict()
+    for image_path in image_paths:
+        with open(image_path, 'rb') as fp:
+            im = PIL.Image.open(fp)
+            sizes.update({str(image_path): im.size})
+    try:
+        for a, b in itertools.combinations(sizes.values(), 2):
+            assert a == b
+    except AssertionError:
+        estr = "\n".join([f"{v}: {k}"
+                          for k, v in sizes.items()])
+        raise NwayException("not all experiments have the same size "
+                            "average projection images, which nway "
+                            "matching currently expects. sizes and image "
+                            f"paths are\n{estr}")
+
+
 class NwayMatching(ArgSchemaParser):
     default_schema = NwayMatchingSchema
     default_output_schema = NwayMatchingOutputSchema
@@ -134,28 +154,17 @@ class NwayMatching(ArgSchemaParser):
             path to json file containing nway matching input
 
         """
-        avg_proj_key = "ophys_average_intensity_projection_image"
         self.experiments = []
-        sizes = dict()
+        image_paths = []
         for exp in self.args['experiment_containers']['ophys_experiments']:
             self.experiments.append(
                     utils.create_nice_mask(
                         exp,
                         self.args['output_directory']))
+            image_paths.append(
+                    Path(exp['ophys_average_intensity_projection_image']))
 
-            with PIL.Image.open(exp[avg_proj_key]) as im:
-                sizes.update({exp['id']: im.size})
-
-        try:
-            for a, b in itertools.combinations(sizes.values(), 2):
-                assert a == b
-        except AssertionError:
-            estr = "\n".join([f"experiment {k}: {v}"
-                              for k, v in sizes.items()])
-            raise NwayException("not all experiments have the same size "
-                                "average projection images, which nway "
-                                "matching currently expects. Experiments "
-                                f"and sizes are\n{estr}")
+        check_image_sizes(image_paths)
 
         if len(self.experiments) < 2:
             raise NwayException("Need at least 2 experiements from input")

--- a/test/test_nway.py
+++ b/test/test_nway.py
@@ -5,6 +5,7 @@ from jinja2 import Template
 import json
 import numpy as np
 import copy
+import PIL.Image
 
 
 TEST_FILE_DIR = os.path.join(
@@ -38,6 +39,39 @@ def input_file(tmpdir):
                 test_files_dir=str(thistest)))
     rendered['log_level'] = "DEBUG"
     yield rendered
+
+
+@pytest.fixture(scope='function')
+def input_file_size_mismatch(tmpdir):
+    thistest = os.path.join(TEST_FILE_DIR, 'test0')
+    myinput = os.path.join(thistest, 'input.json')
+    with open(myinput, 'r') as f:
+        template = Template(json.dumps(json.load(f)))
+    output_dir = str(tmpdir.mkdir("nway_test"))
+    rendered = json.loads(
+            template.render(
+                output_dir=output_dir,
+                test_files_dir=str(thistest)))
+    experiments = rendered['experiment_containers']['ophys_experiments']
+    impath = experiments[0]['ophys_average_intensity_projection_image']
+    with PIL.Image.open(impath) as im:
+        sz = im.size
+        im_cropped = np.array(im)[:, 0:sz[0] - 1]
+    new_path = tmpdir / "cropped_image.png"
+    with PIL.Image.fromarray(im_cropped) as im:
+        im.save(str(new_path))
+    experiments[0]['ophys_average_intensity_projection_image'] = str(new_path)
+    yield rendered
+
+
+def test_nway_size_mismatch_exception(tmpdir, input_file_size_mismatch):
+    args = copy.deepcopy(input_file_size_mismatch)
+    output_dir = str(tmpdir.mkdir("nway_exception"))
+    args['output_directory'] = output_dir
+    nwmatch = nway.NwayMatching(input_data=args, args=[])
+    with pytest.raises(nway.NwayException,
+                       match=r"not all experiments have the same size.*"):
+        nwmatch.run()
 
 
 def test_nway_exception(tmpdir, input_file):


### PR DESCRIPTION
nway cell matching expects that the average projection images in the container are all the same size.
The current failure mode relies on `opencv.phaseCorrelate` failing with the error message:
```
cv2.error: OpenCV(4.4.0) /tmp/pip-req-build-99ib2vsi/opencv/modules/imgproc/src/phasecorr.cpp:524: error: (-215:Assertion failed) src1.size == src2.size in function 'phaseCorrelate'
```

This PR adds an early check, a test for the check, and a more informative message:
```
__main__.NwayException: not all experiments have the same size average projection images, which nway matching currently expects. sizes and image paths are
(449, 512): /allen/programs/braintv/production/visualbehavior/prod0/specimen_789992909/ophys_session_815485890/ophys_experiment_815652334/processed/ophys_cell_segmentation_run_1080895240/avgInt_a1X.png
(449, 512): /allen/programs/braintv/production/visualbehavior/prod0/specimen_789992909/ophys_session_817101568/ophys_experiment_817267785/processed/ophys_cell_segmentation_run_1080850339/avgInt_a1X.png
(447, 512): /allen/programs/braintv/production/visualbehavior/prod0/specimen_789992909/ophys_session_819949602/ophys_experiment_820307518/processed/ophys_cell_segmentation_run_1080863409/avgInt_a1X.png
(447, 512): /allen/programs/braintv/production/visualbehavior/prod0/specimen_789992909/ophys_session_820871900/ophys_experiment_821011078/processed/ophys_cell_segmentation_run_1080861432/avgInt_a1X.png
(447, 512): /allen/programs/braintv/production/visualbehavior/prod0/specimen_789992909/ophys_session_822388759/ophys_experiment_822647135/processed/ophys_cell_segmentation_run_1080895280/avgInt_a1X.png
(447, 512): /allen/programs/braintv/production/visualbehavior/prod0/specimen_789992909/ophys_session_824745199/ophys_experiment_825130141/processed/ophys_cell_segmentation_run_1080861930/avgInt_a1X.png
```