### PR TITLE
adds a zero-padding to match mismatched projection images sizes

### DIFF
--- a/src/nway/nway_matching.py
+++ b/src/nway/nway_matching.py
@@ -7,6 +7,7 @@ import multiprocessing
 import pandas as pd
 import networkx as nx
 import PIL.Image
+import warnings
 from pathlib import Path
 from typing import List
 from nway.pairwise_matching import PairwiseMatching
@@ -134,10 +135,10 @@ def check_image_sizes(image_paths: List[Path]):
     except AssertionError:
         estr = "\n".join([f"{v}: {k}"
                           for k, v in sizes.items()])
-        raise NwayException("not all experiments have the same size "
-                            "average projection images, which nway "
-                            "matching currently expects. sizes and image "
-                            f"paths are\n{estr}")
+        warnings.warn("not all experiments have the same size "
+                      "average projection images. PhaseCorrelate "
+                      "transform will zero-pad to match sizes. "
+                      f"sizes and image paths are\n{estr}")
 
 
 class NwayMatching(ArgSchemaParser):

--- a/src/nway/transforms.py
+++ b/src/nway/transforms.py
@@ -111,6 +111,41 @@ class CLAHE(Transform):
         return mov, fix
 
 
+def pad_to_match(arr1: np.ndarray, arr2: np.ndarray
+                 ) -> Tuple[np.ndarray, np.ndarray]:
+    """
+    given a mismatch in size, per-axis, pad the smaller array
+    to match the larger array size.
+
+    Parameters
+    ----------
+    arr1: np.ndarray
+        first array
+    arr2: np.ndarray
+        first array
+
+    Returns
+    -------
+    arr1: np.ndarray
+        first array, padded where necessary
+    arr2: np.ndarray
+        first array, padded where necessary
+
+    """
+    mxrow = max(arr1.shape[0], arr2.shape[0])
+    drows1 = mxrow - arr1.shape[0]
+    drows2 = mxrow - arr2.shape[0]
+
+    mxcol = max(arr1.shape[1], arr2.shape[1])
+    dcols1 = mxcol - arr1.shape[1]
+    dcols2 = mxcol - arr2.shape[1]
+
+    arr1 = np.pad(arr1, [(0, drows1), (0, dcols1)])
+    arr2 = np.pad(arr2, [(0, drows2), (0, dcols2)])
+
+    return arr1, arr2
+
+
 class PhaseCorrelate(Transform):
     """estimates geometrical transform by phase correlation
     and applies the transform
@@ -125,6 +160,9 @@ class PhaseCorrelate(Transform):
             uint8, needed for opencv operations
 
         """
+        if src.shape != dst.shape:
+            src, dst = pad_to_match(src, dst)
+
         (dx, dy), _ = cv2.phaseCorrelate(src1=dst.astype('float32'),
                                          src2=src.astype('float32'))
         self.matrix = np.eye(3).astype('float32')

--- a/src/nway/transforms.py
+++ b/src/nway/transforms.py
@@ -133,7 +133,7 @@ def pad_to_match(arr1: np.ndarray, arr2: np.ndarray
 
     Notes
     -----
-    paddings are appended to the image dimensions, not inserted at 
+    paddings are appended to the image dimensions, not inserted at
     row/col = 0. This preserves any ROI location information
 
     """

--- a/src/nway/transforms.py
+++ b/src/nway/transforms.py
@@ -122,14 +122,19 @@ def pad_to_match(arr1: np.ndarray, arr2: np.ndarray
     arr1: np.ndarray
         first array
     arr2: np.ndarray
-        first array
+        second array
 
     Returns
     -------
     arr1: np.ndarray
         first array, padded where necessary
     arr2: np.ndarray
-        first array, padded where necessary
+        second array, padded where necessary
+
+    Notes
+    -----
+    paddings are appended to the image dimensions, not inserted at 
+    row/col = 0. This preserves any ROI location information
 
     """
     mxrow = max(arr1.shape[0], arr2.shape[0])

--- a/tests/test_nway.py
+++ b/tests/test_nway.py
@@ -50,8 +50,8 @@ def input_file(tmpdir):
                 contextlib.nullcontext()),
             (
                 [(100, 100), (100, 99), (100, 100)],
-                pytest.raises(
-                    nway.NwayException,
+                pytest.warns(
+                    UserWarning,
                     match=r"not all experiments have the same size.*"))])
 def test_nway_size_mismatch_exception(tmpdir, sizes, context):
     impaths = []

--- a/tests/test_transforms.py
+++ b/tests/test_transforms.py
@@ -74,6 +74,70 @@ def test_CLAHE(src, dst, grid, clip):
     assert fix.shape == dst.shape
 
 
+@pytest.mark.parametrize("switch_order", [True, False])
+@pytest.mark.parametrize(
+        "x, y, expected_x, expected_y",
+        [
+            (
+                np.array([[1, 1],
+                          [1, 1]]),
+                np.array([[1, 1, 1],
+                          [1, 1, 1],
+                          [1, 1, 1]]),
+                np.array([[1, 1, 0],
+                          [1, 1, 0],
+                          [0, 0, 0]]),
+                np.array([[1, 1, 1],
+                          [1, 1, 1],
+                          [1, 1, 1]])),
+            (
+                np.array([[1, 1, 1],
+                          [1, 1, 1]]),
+                np.array([[1, 1, 1],
+                          [1, 1, 1],
+                          [1, 1, 1]]),
+                np.array([[1, 1, 1],
+                          [1, 1, 1],
+                          [0, 0, 0]]),
+                np.array([[1, 1, 1],
+                          [1, 1, 1],
+                          [1, 1, 1]])),
+            (
+                np.array([[1, 1],
+                          [1, 1],
+                          [1, 1]]),
+                np.array([[1, 1, 1],
+                          [1, 1, 1],
+                          [1, 1, 1]]),
+                np.array([[1, 1, 0],
+                          [1, 1, 0],
+                          [1, 1, 0]]),
+                np.array([[1, 1, 1],
+                          [1, 1, 1],
+                          [1, 1, 1]])),
+            (
+                np.array([[1, 1],
+                          [1, 1],
+                          [1, 1]]),
+                np.array([[1, 1, 1],
+                          [1, 1, 1]]),
+                np.array([[1, 1, 0],
+                          [1, 1, 0],
+                          [1, 1, 0]]),
+                np.array([[1, 1, 1],
+                          [1, 1, 1],
+                          [0, 0, 0]])),
+                ])
+def test_pad_to_match(x, y, expected_x, expected_y, switch_order):
+    if switch_order:
+        y, x = nwtf.pad_to_match(y, x)
+    else:
+        x, y = nwtf.pad_to_match(x, y)
+
+    np.testing.assert_array_equal(x, expected_x)
+    np.testing.assert_array_equal(y, expected_y)
+
+
 @pytest.mark.parametrize(
         "src, expected",
         [


### PR DESCRIPTION
## Description
previously, nway matching would raise an exception on mismatched image sizes, because opencv PhaseCorrelate could not handle this.
* exception changed to warning
* for PhaseCorrelate, images mismatched in size are zero-padded to match sizes. The padding is appended at the height/width rather than inserted at row/col = 0, to preserve the ROI locations.

## Validation
The informative exception changed to an informative warning:
```
/home/danielk/repos/ophys_nway_matching/src/nway/nway_matching.py:138: UserWarning: not all experiments have the same size average projection images. PhaseCorrelate transform will zero-pad to match sizes. sizes and image paths are
(449, 512): /allen/programs/braintv/production/visualbehavior/prod0/specimen_789992909/ophys_session_815485890/ophys_experiment_815652334/processed/ophys_cell_segmentation_run_1080895240/avgInt_a1X.png
(449, 512): /allen/programs/braintv/production/visualbehavior/prod0/specimen_789992909/ophys_session_817101568/ophys_experiment_817267785/processed/ophys_cell_segmentation_run_1080850339/avgInt_a1X.png
(447, 512): /allen/programs/braintv/production/visualbehavior/prod0/specimen_789992909/ophys_session_819949602/ophys_experiment_820307518/processed/ophys_cell_segmentation_run_1080863409/avgInt_a1X.png
(447, 512): /allen/programs/braintv/production/visualbehavior/prod0/specimen_789992909/ophys_session_820871900/ophys_experiment_821011078/processed/ophys_cell_segmentation_run_1080861432/avgInt_a1X.png
(447, 512): /allen/programs/braintv/production/visualbehavior/prod0/specimen_789992909/ophys_session_822388759/ophys_experiment_822647135/processed/ophys_cell_segmentation_run_1080895280/avgInt_a1X.png
(447, 512): /allen/programs/braintv/production/visualbehavior/prod0/specimen_789992909/ophys_session_824745199/ophys_experiment_825130141/processed/ophys_cell_segmentation_run_1080861930/avgInt_a1X.png
```

1 previous containers raising the exception now pass:
![nway_match_fraction_plot_2021_02_08_09_57_43](https://user-images.githubusercontent.com/32312979/107261827-a40a3080-69f4-11eb-8f99-c4d54df535e8.png)

The second container does not fail on image size, but, the registration proceeds to reveal other potential data errors in failed registrations.