### PR TITLE
adds substitute option for max projection

### DIFF
--- a/src/nway/schemas.py
+++ b/src/nway/schemas.py
@@ -145,6 +145,17 @@ class NwayMatchingSchema(ArgSchema,
         default=3,
         description=("number of parallel workers for multiprocessing pool "
                      "for executing pairwise matching. If 1, runs serially."))
+    substitute_max_for_avg = fields.Bool(
+        required=False,
+        missing=False,
+        default=False,
+        description=("if set to true, module will attempt to substitute "
+                     "'maxInt_a13a.png' for 'avgInt_a1X.png' in the "
+                     "'ophys_average_intensity_projection_image' fields of "
+                     "the input experiments. The registration is attempted "
+                     "on max rather than avg projections. "
+                     "NOTE: there is a better way to "
+                     "accomplish this. This is a temporary hack."))
 
 
 class PairwiseMatchingSchema(ArgSchema, CommonMatchingParameters):

--- a/tests/test_nway.py
+++ b/tests/test_nway.py
@@ -7,6 +7,7 @@ import numpy as np
 import copy
 import contextlib
 import PIL.Image
+from pathlib import Path
 
 
 TEST_FILE_DIR = os.path.join(
@@ -108,7 +109,10 @@ def sub_experiments(tmpdir, request):
         indirect=['sub_experiments'])
 def test_substitute_max_projection(sub_experiments, context):
     with context:
-        nway.substitute_max_projection(sub_experiments)
+        exps = nway.substitute_max_projection(sub_experiments)
+        for exp in exps:
+            p = Path(exp['ophys_average_intensity_projection_image'])
+            assert p.name == "maxInt_a13a.png"
 
 
 def test_nway_exception(tmpdir, input_file):


### PR DESCRIPTION
## Purpose
certain containers weren't registering very well. Their average projections looked difficult to align, while their max projections looked to have more detail in them for potential success. This was shown to rescue a few struggling containers.

The quick-fix for using this switch is to add:
```
--substitute_max_for_avg True
```
to the LIMS executable args.

## Details
* nway_matching has a new arg `substitute_max_for_avg` (default=False) which will substitute `maxInt_a13a.png` in for  `avgInt_a1X.png`
* these are both segmentation outputs.
* Note: this is not robust to future changes of what the strategy supplies to this module. So, exceptions are raised if the substitution is attempted and the input image does not have the name `avgInt_a1X.png` and if the corresponding `maxInt_a13a.png` does not exist.
* verbose INFO logging is in place to indicate when this has been used:
```
INFO:NwayMatching:substituting max for avg projections.
INFO:NwayMatching:substituted /allen/programs/braintv/production/neuralcoding/prod0/specimen_810573072/ophys_session_846871218/ophys_experiment_847267630/processed/ophys_cell_segmentation_run_1080713533/maxInt_a13a.png for /allen/programs/braintv/production/neuralcoding/prod0/specimen_810573072/ophys_session_846871218/ophys_experiment_847267630/processed/ophys_cell_segmentation_run_1080713533/avgInt_a1X.png as registration input
INFO:NwayMatching:substituted /allen/programs/braintv/production/neuralcoding/prod0/specimen_810573072/ophys_session_847758278/ophys_experiment_848039125/processed/ophys_cell_segmentation_run_1080714550/maxInt_a13a.png for /allen/programs/braintv/production/neuralcoding/prod0/specimen_810573072/ophys_session_847758278/ophys_experiment_848039125/processed/ophys_cell_segmentation_run_1080714550/avgInt_a1X.png as registration input
INFO:NwayMatching:substituted /allen/programs/braintv/production/neuralcoding/prod0/specimen_810573072/ophys_session_848401585/ophys_experiment_848760990/processed/ophys_cell_segmentation_run_1080714490/maxInt_a13a.png for /allen/programs/braintv/production/neuralcoding/prod0/specimen_810573072/ophys_session_848401585/ophys_experiment_848760990/processed/ophys_cell_segmentation_run_1080714490/avgInt_a1X.png as registration input
INFO:NwayMatching:substituted /allen/programs/braintv/production/neuralcoding/prod0/specimen_810573072/ophys_session_848983781/ophys_experiment_849233404/processed/ophys_cell_segmentation_run_1080709335/maxInt_a13a.png for /allen/programs/braintv/production/neuralcoding/prod0/specimen_810573072/ophys_session_848983781/ophys_experiment_849233404/processed/ophys_cell_segmentation_run_1080709335/avgInt_a1X.png as registration input
INFO:NwayMatching:substituted /allen/programs/braintv/production/neuralcoding/prod0/specimen_810573072/ophys_session_850894918/ophys_experiment_851085109/processed/ophys_cell_segmentation_run_1080714071/maxInt_a13a.png for /allen/programs/braintv/production/neuralcoding/prod0/specimen_810573072/ophys_session_850894918/ophys_experiment_851085109/processed/ophys_cell_segmentation_run_1080714071/avgInt_a1X.png as registration input
INFO:NwayMatching:substituted /allen/programs/braintv/production/neuralcoding/prod0/specimen_810573072/ophys_session_851740017/ophys_experiment_851958809/processed/ophys_cell_segmentation_run_1080713386/maxInt_a13a.png for /allen/programs/braintv/production/neuralcoding/prod0/specimen_810573072/ophys_session_851740017/ophys_experiment_851958809/processed/ophys_cell_segmentation_run_1080713386/avgInt_a1X.png as registration input
```